### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish-edge.yaml
+++ b/.github/workflows/publish-edge.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to GH Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: tremor-rs/tremor-runtime/tremor
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -17,7 +17,7 @@ jobs:
           tags: edge
           registry: docker.pkg.github.com
       - name: Publish to Docker Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: tremorproject/tremor
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/publish-tags.yaml
+++ b/.github/workflows/publish-tags.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to GH Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: tremor-rs/tremor-runtime/tremor
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -16,14 +16,14 @@ jobs:
           tag_semver: true
           registry: docker.pkg.github.com
       - name: Publish to Docker Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: tremorproject/tremor
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tag_semver: true
       - name: Publish Tremor Courseware to GH Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: tremor-rs/tremor-runtime/courseware
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -31,7 +31,7 @@ jobs:
           tags: latest
           registry: docker.pkg.github.com
       - name: Publish Tremor Courseware to Docker Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: tremorproject/courseware
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore